### PR TITLE
fix: skip auto-vote on killed Arbitrum vsdCRV gauge

### DIFF
--- a/src/gauge-proposals/protocols/CrvCreateProposal.ts
+++ b/src/gauge-proposals/protocols/CrvCreateProposal.ts
@@ -48,7 +48,8 @@ export class CrvCreateProposal extends CreateProposal {
 
         // Push a vote on mainnet from PK for sdCRV/CRV gauge
         await this.voteCRV(gauges, receipt.id as string, process.env.VOTE_PRIVATE_KEY, this.SDCRV_CRV_GAUGE);
-        await this.voteCRV(gauges, receipt.id as string, process.env.ARBITRUM_VOTE_PRIVATE_KEY, this.ARBITRUM_VSDCRV_GAUGE);
+        // Arbitrum vsdCRV gauge killed on Curve with no replacement, skip auto-vote
+        //await this.voteCRV(gauges, receipt.id as string, process.env.ARBITRUM_VOTE_PRIVATE_KEY, this.ARBITRUM_VSDCRV_GAUGE);
         //await this.voteCRV(gauges, receipt.id as string, process.env.POLYGON_VOTE_PRIVATE_KEY, this.POLYGON_VSDCRV_GAUGE);
     }
 


### PR DESCRIPTION
## Problem
The weekly CRV proposal bot (`CrvCreateProposal`) creates the `sdcrv.eth` gauge vote, then auto-votes StakeDAO's positions on hardcoded gauges. It has been firing the Telegram error:

> Create weekly proposal — Impossible to find target gauge. Proposal id: `0x03af2883…` / target gauge address: `0xf1bb643f953836725c6e48bdd6f1816f871d3e07`

## Cause
`getGauges()` filters out killed gauges (`isKilled === false`). The Arbitrum vsdCRV gauge `0xf1bb643…` ("CRV/vsdCRV/asdCRV v2.1") is now **killed on Curve**, so it's absent from the proposal choices and `voteCRV()` can't match it. No live Arbitrum replacement exists in the votemarket gauge list.

The proposal itself is still created fine — this only fails the Arbitrum auto-vote (job exits 0, GH runs show success).

## Fix
Disable the Arbitrum auto-vote, matching the already-disabled Polygon one. Revert with the new gauge address if Arbitrum vsdCRV is later relisted.