### PR TITLE
fix: retry snapshot hub requests on transient failures

### DIFF
--- a/mirror.ts
+++ b/mirror.ts
@@ -2,7 +2,7 @@ import { request, gql } from "graphql-request";
 import axios from "axios";
 import * as dotenv from "dotenv";
 import { ANGLE_ONCHAIN_SUBGRAPH_URL } from "./utils/constants";
-import { fetchSDProposal, SNAPSHOT_URL } from "./src/mirror/request";
+import { fetchSDProposal, requestWithRetry, SNAPSHOT_URL } from "./src/mirror/request";
 import { createProposal, DEFAULT_MIN_TS, DELAY_ONE_DAYS, DELAY_TWO_DAYS, filterGaugesProposals } from "./src/mirror/utils";
 import { SPACES } from "./src/mirror/spaces";
 import { CHAT_ID_ERROR, sendMessage } from "./utils/telegram";
@@ -54,7 +54,7 @@ const SPACES_DEFAULT_MIN_TS: any = {
 };
 
 const fetchProtocolProposal = async ({ space, minCreated = DEFAULT_MIN_TS }: any) => {
-    const result = (await request(`${SNAPSHOT_URL}/graphql`, QUERY, {
+    const result = (await requestWithRetry(`${SNAPSHOT_URL}/graphql`, QUERY, {
         spaces: [space],
         minCreated: minCreated,
     })) as any;

--- a/src/mirror/request.ts
+++ b/src/mirror/request.ts
@@ -1,6 +1,34 @@
-import { request, gql } from "graphql-request";
+import { request, gql, ClientError } from "graphql-request";
+import { sleep } from "../../utils/sleep";
 
 export const SNAPSHOT_URL = "https://hub.snapshot.org";
+
+const MAX_RETRIES = 4;
+const BASE_DELAY_MS = 1000;
+
+// Snapshot's hub occasionally tears down the connection mid-response
+// ("Premature close"). Those are transient, so retry with exponential backoff.
+// A ClientError with a 4xx status is a real, permanent failure (bad query/auth)
+// and should fail fast.
+export const requestWithRetry = async <T = any>(url: string, query: any, variables?: any): Promise<T> => {
+    let lastError: any;
+    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+        try {
+            return (await request(url, query, variables)) as T;
+        } catch (e: any) {
+            lastError = e;
+            const status = e instanceof ClientError ? e.response?.status : undefined;
+            const permanent = status !== undefined && status >= 400 && status < 500;
+            if (permanent || attempt === MAX_RETRIES) {
+                break;
+            }
+            const delay = BASE_DELAY_MS * Math.pow(2, attempt);
+            console.log(`Snapshot request failed (attempt ${attempt + 1}/${MAX_RETRIES + 1}), retrying in ${delay}ms: ${e.message || e}`);
+            await sleep(delay);
+        }
+    }
+    throw lastError;
+};
 
 export interface SnapshotProposal {
     id: string;
@@ -37,6 +65,6 @@ const QUERY_SD = gql`
 `;
 
 export const fetchSDProposal = async ({ space }: any): Promise<SnapshotProposal[]> => {
-    const result = (await request(`${SNAPSHOT_URL}/graphql`, QUERY_SD, { spaces: [space] })) as any;
+    const result = (await requestWithRetry(`${SNAPSHOT_URL}/graphql`, QUERY_SD, { spaces: [space] })) as any;
     return result.proposals;
 };


### PR DESCRIPTION
## What

The mirror bots (Mirror proposal, Mirror CRV) page on every transient `hub.snapshot.org` failure — `Invalid response body … Premature close`, the hub dropping the connection mid-response. No retry existed, so a single hiccup threw, fired a Telegram alert, and aborted the run.

## Change

Add a `requestWithRetry` wrapper (4 retries, exponential backoff 1s→8s, reusing `utils/sleep`) around both Snapshot hub GraphQL calls:
- `fetchSDProposal` (`src/mirror/request.ts`) — covers Mirror proposal **and** Mirror CRV
- `fetchProtocolProposal` (`mirror.ts`)

Fails fast on a `ClientError` with a 4xx status so genuine query/auth errors still surface immediately.

## Out of scope

The Angle subgraph call and the other `GraphQLClient` instances aren't wrapped — they weren't in the reported errors.