### PR TITLE
fix: use native fetch for snapshot hub graphql calls

### DIFF
--- a/src/gauge-proposals/createProposal.ts
+++ b/src/gauge-proposals/createProposal.ts
@@ -6,8 +6,8 @@ import moment from "moment";
 import * as momentTimezone from "moment-timezone";
 import * as chains from 'viem/chains'
 import * as dotenv from "dotenv";
-import request from "graphql-request";
-import { SNAPSHOT_URL } from "../mirror/request";
+import { GraphQLClient } from "graphql-request";
+import { SNAPSHOT_URL, nativeFetch } from "../mirror/request";
 import { QUERY_BY_ID } from "../mirror/snapshotUtils";
 dotenv.config();
 
@@ -250,7 +250,8 @@ export abstract class CreateProposal {
     }
 
     public async manualVote(proposalId: string): Promise<void> {
-        const result = (await request(`${SNAPSHOT_URL}/graphql`, QUERY_BY_ID, {
+        const client = new GraphQLClient(`${SNAPSHOT_URL}/graphql`, { fetch: nativeFetch });
+        const result = (await client.request(QUERY_BY_ID, {
             id: proposalId
         })) as any;
 

--- a/src/gauge-proposals/yfi.ts
+++ b/src/gauge-proposals/yfi.ts
@@ -4,6 +4,7 @@ import { CHAT_ID_ERROR, sendMessage } from "../../utils/telegram";
 import snapshot from "@snapshot-labs/snapshot.js";
 import { BytesLike, ethers } from "ethers";
 import { gql, GraphQLClient } from "graphql-request";
+import { nativeFetch } from "../mirror/request";
 import { GraphQLResponse } from "../replication/interfaces/graphql";
 
 class YFICreateProposal extends CreateProposal {
@@ -63,7 +64,7 @@ class YFICreateProposal extends CreateProposal {
             }
         }
         `;
-        const graphqlClient = new GraphQLClient('https://hub.snapshot.org/graphql');
+        const graphqlClient = new GraphQLClient('https://hub.snapshot.org/graphql', { fetch: nativeFetch });
         const graphqlResponse: GraphQLResponse = await graphqlClient.request(query);
 
         // If no more proposals, it's done

--- a/src/mirror/request.ts
+++ b/src/mirror/request.ts
@@ -1,4 +1,4 @@
-import { request, gql, ClientError } from "graphql-request";
+import { GraphQLClient, gql, ClientError } from "graphql-request";
 import { sleep } from "../../utils/sleep";
 
 export const SNAPSHOT_URL = "https://hub.snapshot.org";
@@ -6,15 +6,23 @@ export const SNAPSHOT_URL = "https://hub.snapshot.org";
 const MAX_RETRIES = 4;
 const BASE_DELAY_MS = 1000;
 
-// Snapshot's hub occasionally tears down the connection mid-response
-// ("Premature close"). Those are transient, so retry with exponential backoff.
+// graphql-request defaults to node-fetch@2 (via cross-fetch), whose gzip
+// decompression throws ERR_STREAM_PREMATURE_CLOSE when the snapshot hub closes
+// the connection mid-response. That failure is deterministic, not transient, so
+// retrying never recovers it. Node's native fetch (undici) decodes the same
+// response correctly, so force every hub client to use it. Typed `any` because
+// tsconfig's lib does not declare the fetch global.
+export const nativeFetch: any = (globalThis as any).fetch;
+
 // A ClientError with a 4xx status is a real, permanent failure (bad query/auth)
-// and should fail fast.
+// and should fail fast. Anything else (5xx, network blips) is retried with
+// exponential backoff.
 export const requestWithRetry = async <T = any>(url: string, query: any, variables?: any): Promise<T> => {
+    const client = new GraphQLClient(url, { fetch: nativeFetch });
     let lastError: any;
     for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
         try {
-            return (await request(url, query, variables)) as T;
+            return (await client.request(query, variables)) as T;
         } catch (e: any) {
             lastError = e;
             const status = e instanceof ClientError ? e.response?.status : undefined;

--- a/src/mirror/snapshotUtils.ts
+++ b/src/mirror/snapshotUtils.ts
@@ -1,5 +1,5 @@
-import { SNAPSHOT_URL } from "./request";
-import { request, gql } from "graphql-request";
+import { SNAPSHOT_URL, nativeFetch } from "./request";
+import { GraphQLClient, gql } from "graphql-request";
 
 // https://github.com/snapshot-labs/snapshot.js/blob/master/src/schemas/proposal.json
 export const MAX_LENGTH_TITLE = 256;
@@ -48,7 +48,8 @@ query Proposal($id: String) {
 `;
 
 export const fetchNbActiveProtocolProposal = async (author: string) => {
-    const result = (await request(`${SNAPSHOT_URL}/graphql`, QUERY_ACTIVE, {
+    const client = new GraphQLClient(`${SNAPSHOT_URL}/graphql`, { fetch: nativeFetch });
+    const result = (await client.request(QUERY_ACTIVE, {
         author
     })) as any;
     return result.proposals.length;

--- a/src/replication/manualYbVote.ts
+++ b/src/replication/manualYbVote.ts
@@ -12,6 +12,7 @@
  */
 
 import { gql, GraphQLClient } from "graphql-request";
+import { nativeFetch } from "../mirror/request";
 import * as dotenv from "dotenv";
 import {
     createPublicClient, createWalletClient, encodeFunctionData,
@@ -75,7 +76,7 @@ type VoteArg = {
 
 const buildVoteArgs = async (): Promise<{ voteArgs: VoteArg[]; titles: Map<string, string> }> => {
     // 1. Fetch active Snapshot proposals
-    const graphqlClient = new GraphQLClient('https://hub.snapshot.org/graphql');
+    const graphqlClient = new GraphQLClient('https://hub.snapshot.org/graphql', { fetch: nativeFetch });
     const query = gql`
       {
         proposals(

--- a/src/replication/replication.ts
+++ b/src/replication/replication.ts
@@ -1,4 +1,5 @@
 import { gql, GraphQLClient } from "graphql-request";
+import { nativeFetch } from "../mirror/request";
 import snapshot from "@snapshot-labs/snapshot.js";
 import { JsonRpcProvider } from "@ethersproject/providers";
 import { Wallet } from "@ethersproject/wallet";
@@ -47,7 +48,7 @@ const ANGLE_LOCKER = "0xD13F8C25CceD32cdfA79EB5eD654Ce3e484dCAF5"
 const ANGLE_VOTER = "0x0E0F27b9d5F2bc742Bf547968d2f07dECBCf1A23"
 
 // Snapshot
-const graphqlClient = new GraphQLClient('https://hub.snapshot.org/graphql');
+const graphqlClient = new GraphQLClient('https://hub.snapshot.org/graphql', { fetch: nativeFetch });
 const HUB_CLIENT = 'https://hub.snapshot.org';
 
 const spaces: Record<string, string> = {


### PR DESCRIPTION
## Why
The merged retry PR didn't fix the mirror failures ([run 28178636806](https://github.com/stake-dao/snapshot-helpers/actions/runs/28178636806)) — and it can't, because the failure isn't transient.

`graphql-request` → `cross-fetch` → **node-fetch@2** throws `ERR_STREAM_PREMATURE_CLOSE` from its gzip-decompression stream when `hub.snapshot.org` closes the connection mid-response. It fails deterministically, so retrying burns all 5 attempts and reports the same error. `curl` and Node's native `fetch` (undici) decode the identical response fine.

## What
Force every active `hub.snapshot.org/graphql` call to use Node's native `fetch` via a shared `nativeFetch` export, removing node-fetch from the path:

- `request.ts` (`requestWithRetry`), `snapshotUtils.ts`, `createProposal.ts`, `replication.ts`, `yfi.ts`, `manualYbVote.ts`
- Retry wrapper kept as a genuine-transient safety net.

## Notes
- The premature-close is CI/runner-specific and can't be reproduced locally; verified the native-fetch path returns proposals end-to-end under full ts-node typechecking.
- `replication_old.ts` (dead code) and non-hub endpoints (Balancer, YieldBasis, Angle subgraph) left as-is — out of scope, not failing.