### PR TITLE
fix: use native fetch for remaining graphql endpoints

### DIFF
--- a/src/gauge-proposals/bal.ts
+++ b/src/gauge-proposals/bal.ts
@@ -1,5 +1,6 @@
 import { CreateProposal } from "./createProposal";
-import request, { gql } from "graphql-request";
+import { GraphQLClient, gql } from "graphql-request";
+import { nativeFetch } from "../mirror/request";
 import moment from "moment";
 import { sleep } from "../../utils/sleep";
 import { CHAT_ID_ERROR, sendMessage } from "../../utils/telegram";
@@ -58,7 +59,8 @@ class BalCreateProposal extends CreateProposal {
             }
         }`;
 
-        const data = (await request("https://api-v3.balancer.fi/", query)) as any;
+        const client = new GraphQLClient("https://api-v3.balancer.fi/", { fetch: nativeFetch });
+        const data = (await client.request(query)) as any;
         const gauges = data.veBalGetVotingList.filter((item: any) => !item.gauge.isKilled);
 
         const response: string[] = [];

--- a/src/mirror/utils.ts
+++ b/src/mirror/utils.ts
@@ -2,7 +2,7 @@ import * as dotenv from "dotenv";
 import { Wallet } from "ethers";
 import { JsonRpcProvider } from "@ethersproject/providers";
 import { CHAIN_ID_TO_RPC } from "../../utils/constants";
-import { SNAPSHOT_URL } from "./request";
+import { SNAPSHOT_URL, nativeFetch } from "./request";
 import snapshot from "@snapshot-labs/snapshot.js";
 import { fetchNbActiveProtocolProposal, MAX_LENGTH_BODY, MAX_LENGTH_TITLE } from "./snapshotUtils";
 import { createPublicClient, http } from "viem";
@@ -10,7 +10,7 @@ import * as chains from 'viem/chains'
 import axios from "axios";
 import { SPACES } from "./spaces";
 import { CHAT_ID_ERROR, sendMessage } from "../../utils/telegram";
-import request, { gql } from "graphql-request";
+import { GraphQLClient, gql } from "graphql-request";
 
 dotenv.config();
 
@@ -163,7 +163,8 @@ export interface YBProposal {
 }
 
 export const fetchYbProposals = async (): Promise<YBProposal[]> => {
-    const result = (await request("https://data.yieldbasis.com/api/v1/graphql", gql`
+    const client = new GraphQLClient("https://data.yieldbasis.com/api/v1/graphql", { fetch: nativeFetch });
+    const result = (await client.request(gql`
         query GetAllProposals($chainId: Int!) {
             proposals: Proposal(limit: 1000, where: {chainId: {_eq: $chainId}}) {
                 ...ProposalFields

--- a/src/replication/replication.ts
+++ b/src/replication/replication.ts
@@ -396,7 +396,7 @@ const _getOriginalProposal = async (proposal: Proposal, space: string, originSpa
 }
 
 const getOriginalAngleProposal = async (proposal: Proposal): Promise<AngleProposal | undefined> => {
-    const graphqlClient = new GraphQLClient(ANGLE_ONCHAIN_SUBGRAPH_URL);
+    const graphqlClient = new GraphQLClient(ANGLE_ONCHAIN_SUBGRAPH_URL, { fetch: nativeFetch });
 
     const graphqlRequest = gql`
         query {


### PR DESCRIPTION
## Why
Follow-up to #36. After the snapshot-hub fix, [run 28180460892](https://github.com/stake-dao/snapshot-helpers/actions/runs/28180460892) got past `mirror-crv` and failed at `mirror-yb` with the **same** `ERR_STREAM_PREMATURE_CLOSE` — this time on `data.yieldbasis.com`. The node-fetch@2 gzip bug is endpoint-agnostic, so scoping the previous fix to the hub only moved the failure one step down.

## What
Extend the `nativeFetch` fix to every remaining graphql-request endpoint in active workflows:
- `mirror/utils.ts` — YieldBasis (`mirror-yb`)
- `gauge-proposals/bal.ts` — Balancer (weekly bal proposal)
- `replication/replication.ts` — Angle on-chain subgraph (`replication`)

## Verified
`fetchYbProposals` runs end-to-end under full ts-node typechecking → 50 proposals. No graphql-request call site on active paths still uses node-fetch (`replication_old.ts` is dead code, left as-is).