### PR TITLE
fix: prevent mirror from creating duplicate proposals

### DIFF
--- a/.github/workflows/delete-proposals.yaml
+++ b/.github/workflows/delete-proposals.yaml
@@ -1,0 +1,33 @@
+name: "Delete proposals (manual)"
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "dry-run (print only) or execute (cancel on Snapshot)"
+        required: true
+        type: choice
+        options:
+          - dry-run
+          - execute
+        default: dry-run
+      proposal_ids:
+        description: "Comma-separated Snapshot proposal IDs to delete"
+        required: true
+        type: string
+
+env:
+  PK_1: ${{ secrets.PK_1 }}
+  PK_2: ${{ secrets.PK_2 }}
+  PK_3: ${{ secrets.PK_3 }}
+
+jobs:
+  delete-proposals:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: npm install
+      - run: npm run delete-proposals -- "$MODE" "$PROPOSAL_IDS"
+        env:
+          MODE: ${{ inputs.mode }}
+          PROPOSAL_IDS: ${{ inputs.proposal_ids }}

--- a/package.json
+++ b/package.json
@@ -35,6 +35,8 @@
     "mirror": "npx ts-node mirror.ts",
     "mirror-crv": "npx ts-node src/mirror/crv.ts",
     "mirror-yb": "npx ts-node src/mirror/yb.ts",
+    "delete-proposals": "npx ts-node src/mirror/delete-proposals.ts",
+    "test:dedup": "npx ts-node src/mirror/dedup.test.ts",
     "replication": "npx ts-node src/replication/replication.ts",
     "replication-old": "npx ts-node src/replication/replication_old.ts",
     "manual-yb-vote": "npx ts-node --transpile-only src/replication/manualYbVote.ts",

--- a/src/mirror/dedup.test.ts
+++ b/src/mirror/dedup.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert";
+import { hasProposalWithTitle } from "./snapshotUtils";
+
+const TITLE = "BlackPool DAO — Final Wind-Down and Treasury Distribution";
+
+// Existing active proposal with the same title -> duplicate detected, mirror skips.
+assert.strictEqual(
+    hasProposalWithTitle([{ title: "Other" }, { title: TITLE }], TITLE),
+    true,
+    "should detect an existing proposal with the same title",
+);
+
+// No existing proposals -> not a duplicate.
+assert.strictEqual(
+    hasProposalWithTitle([], TITLE),
+    false,
+    "empty space should not report a duplicate",
+);
+
+// Only different titles -> not a duplicate.
+assert.strictEqual(
+    hasProposalWithTitle([{ title: "Something else" }], TITLE),
+    false,
+    "different titles should not match",
+);
+
+console.log("dedup.test.ts: all assertions passed");

--- a/src/mirror/delete-proposals.ts
+++ b/src/mirror/delete-proposals.ts
@@ -1,0 +1,86 @@
+import * as dotenv from "dotenv";
+import { Wallet } from "ethers";
+import snapshot from "@snapshot-labs/snapshot.js";
+import { GraphQLClient, gql } from "graphql-request";
+import { SNAPSHOT_URL, nativeFetch } from "./request";
+
+dotenv.config();
+
+// One-off / on-demand tool to delete Snapshot proposals (e.g. mirror duplicates).
+// Usage: ts-node src/mirror/delete-proposals.ts <dry-run|execute> <id[,id...]>
+// A proposal can only be deleted by its author, so each id is matched to the
+// PK_1/PK_2/PK_3 key that signed it. Signing is offline; no RPC needed.
+
+const QUERY = gql`
+    query Proposals($ids: [String!]) {
+        proposals(where: { id_in: $ids }, first: 1000) {
+            id
+            title
+            state
+            author
+            space {
+                id
+            }
+        }
+    }
+`;
+
+const main = async () => {
+    const mode = process.argv[2] === "execute" ? "execute" : "dry-run";
+    const ids = process.argv
+        .slice(3)
+        .flatMap((arg) => arg.split(","))
+        .map((id) => id.trim())
+        .filter(Boolean);
+
+    if (ids.length === 0) {
+        console.log("No proposal ids provided. Usage: <dry-run|execute> <id[,id...]>");
+        return;
+    }
+
+    const client = new snapshot.Client712(SNAPSHOT_URL);
+    const gqlClient = new GraphQLClient(`${SNAPSHOT_URL}/graphql`, { fetch: nativeFetch });
+
+    const wallets = [process.env.PK_1, process.env.PK_2, process.env.PK_3]
+        .filter(Boolean)
+        .map((pk) => new Wallet(pk as string));
+
+    const { proposals } = (await gqlClient.request(QUERY, { ids })) as any;
+    const byId = new Map<string, any>(proposals.map((p: any) => [p.id.toLowerCase(), p]));
+
+    console.log(`Mode: ${mode}. Targets: ${ids.length}`);
+
+    for (const id of ids) {
+        const proposal = byId.get(id.toLowerCase());
+        if (!proposal) {
+            console.log(`[skip] ${id} - not found on hub`);
+            continue;
+        }
+
+        const signer = wallets.find((w) => w.address.toLowerCase() === proposal.author.toLowerCase());
+        if (!signer) {
+            console.log(`[skip] ${id} - author ${proposal.author} is not one of PK_1/PK_2/PK_3`);
+            continue;
+        }
+
+        console.log(`[${mode}] ${id} "${proposal.title}" state=${proposal.state} space=${proposal.space.id} author=${proposal.author}`);
+        if (mode !== "execute") {
+            continue;
+        }
+
+        try {
+            const receipt = await client.cancelProposal(signer as any, signer.address, {
+                space: proposal.space.id,
+                proposal: id,
+            });
+            console.log(`  deleted:`, receipt);
+        } catch (e: any) {
+            console.log(`  ERROR deleting ${id}:`, e.error_description || e.message || e);
+        }
+    }
+};
+
+main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+});

--- a/src/mirror/snapshotUtils.ts
+++ b/src/mirror/snapshotUtils.ts
@@ -1,4 +1,4 @@
-import { SNAPSHOT_URL, nativeFetch } from "./request";
+import { SNAPSHOT_URL, nativeFetch, requestWithRetry } from "./request";
 import { GraphQLClient, gql } from "graphql-request";
 
 // https://github.com/snapshot-labs/snapshot.js/blob/master/src/schemas/proposal.json
@@ -54,3 +54,29 @@ export const fetchNbActiveProtocolProposal = async (author: string) => {
     })) as any;
     return result.proposals.length;
 };
+
+const QUERY_ACTIVE_BY_SPACE = gql`
+query ProposalsBySpace($space: String!) {
+    proposals(
+      where: {
+        space: $space
+        state: "active"
+      }
+      first: 1000
+      orderBy: "created"
+      orderDirection: desc
+    ) {
+      id
+      title
+    }
+  }
+`;
+
+export const fetchActiveProposalsInSpace = async (space: string): Promise<{ id: string; title: string }[]> => {
+    const result = (await requestWithRetry(`${SNAPSHOT_URL}/graphql`, QUERY_ACTIVE_BY_SPACE, { space })) as any;
+    return result.proposals;
+};
+
+// Pure: is there already an active proposal with this exact title in the space?
+export const hasProposalWithTitle = (proposals: { title: string }[], title: string): boolean =>
+    proposals.some((p) => p.title === title);

--- a/src/mirror/utils.ts
+++ b/src/mirror/utils.ts
@@ -4,7 +4,8 @@ import { JsonRpcProvider } from "@ethersproject/providers";
 import { CHAIN_ID_TO_RPC } from "../../utils/constants";
 import { SNAPSHOT_URL, nativeFetch } from "./request";
 import snapshot from "@snapshot-labs/snapshot.js";
-import { fetchNbActiveProtocolProposal, MAX_LENGTH_BODY, MAX_LENGTH_TITLE } from "./snapshotUtils";
+import { fetchActiveProposalsInSpace, fetchNbActiveProtocolProposal, hasProposalWithTitle, MAX_LENGTH_BODY, MAX_LENGTH_TITLE } from "./snapshotUtils";
+import { sleep } from "../../utils/sleep";
 import { createPublicClient, http } from "viem";
 import * as chains from 'viem/chains'
 import axios from "axios";
@@ -52,30 +53,43 @@ export const createProposal = async ({ payload }: any) => {
     const provider = new JsonRpcProvider(CHAIN_ID_TO_RPC[1]);
     const snapshotClient = new snapshot.Client712(SNAPSHOT_URL);
     const pks = [process.env.PK_1, process.env.PK_2, process.env.PK_3];
+    const targetSpace = SPACES[payload.space.id];
     let created = false;
+
+    let title = payload.title;
+    let body = payload.body;
+
+    if (title && title.length > MAX_LENGTH_TITLE) {
+        title = title.substring(0, MAX_LENGTH_TITLE - 3) + "...";
+    }
+
+    if (body && body.length > MAX_LENGTH_BODY) {
+        body = body.substring(0, MAX_LENGTH_BODY - 3) + "...";
+    }
+
+    title = title || "No title";
+    body = body || "No body";
 
     for (const pk of pks) {
         const signer = new Wallet(pk, (provider as any));
         const address = signer.address;
+
+        // Idempotency guard. snapshot.js' write can succeed on the hub while the
+        // client throws reading the response (ERR_STREAM_PREMATURE_CLOSE). That
+        // used to make the loop fail over to the next key and recreate the same
+        // proposal, once per key. Re-check the target space before each attempt
+        // so a proposal that already landed is never duplicated.
+        if (hasProposalWithTitle(await fetchActiveProposalsInSpace(targetSpace), title)) {
+            console.log("Proposal already active in " + targetSpace + ", skip: " + title);
+            created = true;
+            break;
+        }
+
         const nbActiveProposal = await fetchNbActiveProtocolProposal(address);
         if (nbActiveProposal >= 10) {
             console.log("nbActiveProposal > 10 => " + nbActiveProposal + ", we can't add proposal for " + payload.space.id)
             continue;
         }
-
-        let title = payload.title;
-        let body = payload.body;
-
-        if (title && title.length > MAX_LENGTH_TITLE) {
-            title = title.substring(0, MAX_LENGTH_TITLE - 3) + "...";
-        }
-
-        if (body && body.length > MAX_LENGTH_BODY) {
-            body = body.substring(0, MAX_LENGTH_BODY - 3) + "...";
-        }
-
-        title = title || "No title";
-        body = body || "No body";
 
         let network = "1"
         switch (payload.space.id) {
@@ -95,7 +109,7 @@ export const createProposal = async ({ payload }: any) => {
         }
 
         const proposal: any = {
-            space: SPACES[payload.space.id],
+            space: targetSpace,
             type: payload.type,
             title: title,
             name: title,
@@ -117,12 +131,21 @@ export const createProposal = async ({ payload }: any) => {
             break;
         } catch (e: any) {
             console.log("ERR", e);
-            await sendMessage(process.env.TG_API_KEY_BOT_ERROR, CHAT_ID_ERROR, "Mirror", `Space ${SPACES[payload.space.id]} - ${e.error_description || e.message || ""}`)
+            await sendMessage(process.env.TG_API_KEY_BOT_ERROR, CHAT_ID_ERROR, "Mirror", `Space ${targetSpace} - ${e.error_description || e.message || ""}`)
+            // The write may have landed on the hub even though the client threw.
+            // Verify (after a short indexing delay) before failing over to the
+            // next key, otherwise we would create the proposal twice.
+            await sleep(2000);
+            if (hasProposalWithTitle(await fetchActiveProposalsInSpace(targetSpace), title)) {
+                console.log("Proposal created despite client error, not retrying: " + title);
+                created = true;
+                break;
+            }
         }
     }
 
     if (!created) {
-        await sendMessage(process.env.TG_API_KEY_BOT_ERROR, CHAT_ID_ERROR, "Mirror", `Space ${SPACES[payload.space.id]}`)
+        await sendMessage(process.env.TG_API_KEY_BOT_ERROR, CHAT_ID_ERROR, "Mirror", `Space ${targetSpace}`)
     }
 };
 


### PR DESCRIPTION
## Problem

The BlackPool wind-down proposal was mirrored **3×** to `sdbpt.eth` (three distinct proposal IDs, identical title/body/window, created within 3 seconds, one per signing key).

## Root cause

`createProposal` (`src/mirror/utils.ts`) loops over `[PK_1, PK_2, PK_3]` as a **failover** — try a key, `break` on success, try the next only on failure. But `snapshot.js`'s `Client712.proposal()` can **persist the proposal on the hub and then throw while reading the response** (same `ERR_STREAM_PREMATURE_CLOSE` the read path was already patched for; the write path still uses snapshot.js' own fetch). The thrown error was treated as a failure, so the loop failed over to the next key and created the proposal again — once per key.

The `mirror-snapshot-retry` work added retries/native-fetch to the GraphQL **reads** only; the **write** was never idempotent.

## Fix

Idempotency guard in `createProposal`:
- before each key attempt, re-check the target space for an active proposal with the same title → skip if present;
- in the `catch`, after a short indexing delay, re-check before failing over — if the write actually landed, stop instead of retrying with another key.

## Cleanup of the 3 live duplicates

Adds `delete-proposals.ts` + a manual `workflow_dispatch` workflow (`Delete proposals (manual)`). It matches each proposal's author to the right `PK_n` and cancels it on Snapshot.

Run the workflow with **mode = `dry-run`** first to confirm, then **`execute`**, keeping one and deleting the other two:

- keep: `0x19f5304d5e261e778d557611a6aad39a4edd18e74251741caa8230b8d117325f`
- delete (`proposal_ids`): `0x60676e088be6c62286320ea549f5bb3a3d34ec4c3c9fe8ba97ace8dd642da081,0x5051ecfee4720c1251c589530f7f2444644d29de8a779328f3331eee0b66460e`

## Test

`npm run test:dedup` covers the dedup decision. Dry-run of `delete-proposals` verified against the live hub (fetches the 3 IDs, resolves authors correctly).